### PR TITLE
remove padding from bio-img-container in mobile mode

### DIFF
--- a/stylesheets/css.css
+++ b/stylesheets/css.css
@@ -50,6 +50,9 @@ http://bdinfosys.com/demo/?item=materialx
 	.bio-image-container {
 		max-height: 285px;
 		overflow: hidden;
+		margin-left: -20px;
+		margin-right: -20px;
+		margin-top: -20px;
 	}
 	.bio-image {
 		width: 100%;


### PR DESCRIPTION
## Before

![screen shot 2015-05-16 at 8 42 36 pm](https://cloud.githubusercontent.com/assets/558005/7668933/6976217e-fc0c-11e4-86a5-05438eabd291.png)
## After

![screen shot 2015-05-16 at 8 44 09 pm](https://cloud.githubusercontent.com/assets/558005/7668932/6962fd2e-fc0c-11e4-965c-8bb07f4fb1f7.png)
